### PR TITLE
feat: add configurable keybind for preset dialogs

### DIFF
--- a/l10n/l10n_br.xml
+++ b/l10n/l10n_br.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="Abrir predefinições" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="Predefinições de Veículo" />
     <e k="vehiclePresets_presetName" v="Nome da Predefinição" />

--- a/l10n/l10n_cs.xml
+++ b/l10n/l10n_cs.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="打开预设" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="车辆预设" />
     <e k="vehiclePresets_presetName" v="预设名称" />

--- a/l10n/l10n_ct.xml
+++ b/l10n/l10n_ct.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="開啟預設" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="車輛預設" />
     <e k="vehiclePresets_presetName" v="預設名稱" />

--- a/l10n/l10n_cz.xml
+++ b/l10n/l10n_cz.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="Otevřít předvolby" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="Předvolby vozidla" />
     <e k="vehiclePresets_presetName" v="Název předvolby" />

--- a/l10n/l10n_da.xml
+++ b/l10n/l10n_da.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="Åbn forudindstillinger" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="Køretøjsforudindstillinger" />
     <e k="vehiclePresets_presetName" v="Forudindstillingsnavn" />

--- a/l10n/l10n_de.xml
+++ b/l10n/l10n_de.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="Presets öffnen" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="Fahrzeug-Vorlagen" />
     <e k="vehiclePresets_presetName" v="Vorlagenname" />

--- a/l10n/l10n_ea.xml
+++ b/l10n/l10n_ea.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="Abrir preajustes" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="Ajustes de Vehículo" />
     <e k="vehiclePresets_presetName" v="Nombre del Ajuste" />

--- a/l10n/l10n_en.xml
+++ b/l10n/l10n_en.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="Open Presets" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="Vehicle Presets" />
     <e k="vehiclePresets_presetName" v="Preset Name" />

--- a/l10n/l10n_es.xml
+++ b/l10n/l10n_es.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="Abrir preajustes" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="Ajustes de Vehículo" />
     <e k="vehiclePresets_presetName" v="Nombre del Ajuste" />

--- a/l10n/l10n_fc.xml
+++ b/l10n/l10n_fc.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="Ouvrir les préréglages" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="Préréglages VHC" />
     <e k="vehiclePresets_presetName" v="Nom préréglage" />

--- a/l10n/l10n_fi.xml
+++ b/l10n/l10n_fi.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="Avaa esiasetukset" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="Ajoneuvon Esiasetukset" />
     <e k="vehiclePresets_presetName" v="Esiasetuksen Nimi" />

--- a/l10n/l10n_fr.xml
+++ b/l10n/l10n_fr.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="Ouvrir les préréglages" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="Préréglages Véhicule" />
     <e k="vehiclePresets_presetName" v="Nom du préréglage" />

--- a/l10n/l10n_hu.xml
+++ b/l10n/l10n_hu.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="Előbeállítások megnyitása" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="Jármű Előbeállítások" />
     <e k="vehiclePresets_presetName" v="Előbeállítás Neve" />

--- a/l10n/l10n_id.xml
+++ b/l10n/l10n_id.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="Buka Preset" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="Preset Kendaraan" />
     <e k="vehiclePresets_presetName" v="Nama Preset" />

--- a/l10n/l10n_it.xml
+++ b/l10n/l10n_it.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="Apri preset" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="Preset Veicolo" />
     <e k="vehiclePresets_presetName" v="Nome Preset" />

--- a/l10n/l10n_jp.xml
+++ b/l10n/l10n_jp.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="プリセットを開く" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="車両プリセット" />
     <e k="vehiclePresets_presetName" v="プリセット名" />

--- a/l10n/l10n_kr.xml
+++ b/l10n/l10n_kr.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="프리셋 열기" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="차량 프리셋" />
     <e k="vehiclePresets_presetName" v="프리셋 이름" />

--- a/l10n/l10n_meta.xml
+++ b/l10n/l10n_meta.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="" />
     <e k="vehiclePresets_presetName" v="" />

--- a/l10n/l10n_nl.xml
+++ b/l10n/l10n_nl.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="Voorinstellingen openen" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="Voertuigvoorinstellingen" />
     <e k="vehiclePresets_presetName" v="Voorinstellingsnaam" />

--- a/l10n/l10n_no.xml
+++ b/l10n/l10n_no.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="Åpne forhåndsinnstillinger" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="Kjøretøyforhåndsinnst." />
     <e k="vehiclePresets_presetName" v="Forhåndsinnstilling Navn" />

--- a/l10n/l10n_pl.xml
+++ b/l10n/l10n_pl.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="Otwórz presety" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="Konfiguracje Pojazdu" />
     <e k="vehiclePresets_presetName" v="Nazwa Konfiguracji" />

--- a/l10n/l10n_pt.xml
+++ b/l10n/l10n_pt.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="Abrir predefinições" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="Ajustes de Veículo" />
     <e k="vehiclePresets_presetName" v="Nome do Ajuste" />

--- a/l10n/l10n_ro.xml
+++ b/l10n/l10n_ro.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="Deschide presetările" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="Presetări Vehicul" />
     <e k="vehiclePresets_presetName" v="Nume Presetare" />

--- a/l10n/l10n_ru.xml
+++ b/l10n/l10n_ru.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="Открыть пресеты" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="Пресеты техники" />
     <e k="vehiclePresets_presetName" v="Название пресета" />

--- a/l10n/l10n_sv.xml
+++ b/l10n/l10n_sv.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="Öppna förinställningar" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="Förinställ. Fordon" />
     <e k="vehiclePresets_presetName" v="Namn förinställning" />

--- a/l10n/l10n_tr.xml
+++ b/l10n/l10n_tr.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="Ön ayarları aç" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="Araç Ön Ayarları" />
     <e k="vehiclePresets_presetName" v="Ön Ayar Adı" />

--- a/l10n/l10n_uk.xml
+++ b/l10n/l10n_uk.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="Відкрити пресети" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="Пресети техніки" />
     <e k="vehiclePresets_presetName" v="Назва пресету" />

--- a/l10n/l10n_vi.xml
+++ b/l10n/l10n_vi.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <l10n>
   <elements>
+    <!-- Input Actions -->
+    <e k="input_VEHICLE_PRESETS" v="Mở cài đặt sẵn" />
+
     <!-- General UI -->
     <e k="vehiclePresets_dialogTitle" v="Các mẫu thiết lập xe" />
     <e k="vehiclePresets_presetName" v="Tên thiết lập" />

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
-<modDesc descVersion="107">
+<modDesc descVersion="108">
   <author>aaw3k</author>
-  <version>1.0.0.0</version>
+  <version>1.0.1.0</version>
 
   <title>
     <en>Vehicle Presets</en>
@@ -23,8 +23,11 @@ Features:
 - Automatically removes presets for uninstalled mod vehicles.
 
 Hotkeys:
-- Press 'X' to open the "All Presets" browser directly from the store pages.
-- Press 'X' to open the "Presets" dialog in the shop configuration screen.
+- Press 'V' to open the "All Presets" browser directly from the store pages.
+- Press 'V' to open the "Presets" dialog in the shop configuration screen.
+
+Changelog Version 1.0.1.0:
+- Added ability to change the keybind for opening preset dialogs.
 
 For more info, bug reports, or to contribute, check out GitHub (modnext/vehiclePresets).
 ]]></en>
@@ -39,8 +42,11 @@ Funktionen:
 - Entfernt automatisch Presets für deinstallierte Mod-Fahrzeuge.
 
 Tastenkombinationen:
-- Drücke 'X', um den "Alle Presets"-Browser direkt aus dem Menü zu öffnen.
-- Drücke 'X', um den "Presets"-Dialog im Shop-Konfigurationsbildschirm zu öffnen.
+- Drücke 'V', um den "Alle Presets"-Browser direkt aus dem Menü zu öffnen.
+- Drücke 'V', um den "Presets"-Dialog im Shop-Konfigurationsbildschirm zu öffnen.
+
+Changelog Version 1.0.1.0:
+- Möglichkeit hinzugefügt, die Tastenbelegung zum Öffnen der Preset-Dialoge zu ändern.
 
 Für mehr Infos, Fehlermeldungen oder kleine Beiträge schau einfach auf GitHub vorbei (modnext/vehiclePresets).
 ]]></de>
@@ -55,8 +61,11 @@ Fonctionnalités :
 - Supprime automatiquement les préréglages des véhicules de mods désinstallés.
 
 Raccourcis clavier :
-- Appuyez sur 'X' pour ouvrir le navigateur "Préréglages" directement depuis les pages de la boutique.
-- Appuyez sur 'X' pour ouvrir la boîte de dialogue "Préréglages" dans l'écran de configuration.
+- Appuyez sur 'V' pour ouvrir le navigateur "Préréglages" directement depuis les pages de la boutique.
+- Appuyez sur 'V' pour ouvrir la boîte de dialogue "Préréglages" dans l'écran de configuration.
+
+Changelog Version 1.0.1.0 :
+- Ajout de la possibilité de modifier la touche pour ouvrir les dialogues de préréglages.
 
 Pour plus d'infos, signaler un bug ou apporter votre aide, rendez-vous sur GitHub (modnext/vehiclePresets).
 ]]></fr>
@@ -71,8 +80,11 @@ Funkcje:
 - Automatycznie usuwa presety dla pojazdów z odinstalowanych modów.
 
 Skróty klawiszowe:
-- Wciśnij 'X', aby otworzyć przeglądarkę "Wszystkich Presetów" prosto ze stron sklepu.
-- Wciśnij 'X', aby otworzyć okno presetów w ekranie konfiguracji pojazdu.
+- Wciśnij 'V', aby otworzyć przeglądarkę "Wszystkich Presetów" prosto ze stron sklepu.
+- Wciśnij 'V', aby otworzyć okno presetów w ekranie konfiguracji pojazdu.
+
+Changelog Version 1.0.1.0:
+- Dodano możliwość zmiany klawisza do otwierania okien presetów.
 
 Więcej informacji, zgłaszanie błędów czy pomoc w rozwoju znajdziecie na moim GitHubie (modnext/vehiclePresets).
 ]]></pl>
@@ -86,8 +98,11 @@ Więcej informacji, zgłaszanie błędów czy pomoc w rozwoju znajdziecie na moi
 - Автоматически удаляет пресеты для техники из удаленных модов.
 
 Горячие клавиши:
-- Нажмите «X», чтобы открыть браузер «Все пресеты» прямо со страниц магазина.
-- Нажмите «X», чтобы открыть диалоговое окно «Пресеты» на экране конфигурации.
+- Нажмите «V», чтобы открыть браузер «Все пресеты» прямо со страниц магазина.
+- Нажмите «V», чтобы открыть диалоговое окно «Пресеты» на экране конфигурации.
+
+Changelog Version 1.0.1.0:
+- Добавлена возможность изменить клавишу для открытия диалогов пресетов.
 
 Для получения дополнительной информации, сообщений об ошибках или участия загляните на GitHub (modnext/vehiclePresets).
 ]]></ru>
@@ -105,4 +120,14 @@ Więcej informacji, zgłaszanie błędów czy pomoc w rozwoju znajdziecie na moi
     <sourceFile filename="scripts/extensions/ShopConfigScreenExtension.lua" />
     <sourceFile filename="scripts/extensions/ShopMenuExtension.lua" />
   </extraSourceFiles>
+
+  <actions>
+    <action name="VEHICLE_PRESETS" axisType="HALF" displayCategory="MENU" />
+  </actions>
+
+  <inputBinding>
+    <actionBinding action="VEHICLE_PRESETS">
+      <binding device="KB_MOUSE_DEFAULT" input="KEY_v" />
+    </actionBinding>
+  </inputBinding>
 </modDesc>

--- a/scripts/extensions/ShopConfigScreenExtension.lua
+++ b/scripts/extensions/ShopConfigScreenExtension.lua
@@ -184,7 +184,7 @@ local function updateButtons(self, superFunc, storeItem, vehicle, saleItem)
 
     self.presetsButton:setText(g_i18n:getText("vehiclePresets_dialogTitle"))
     self.presetsButton:applyProfile(ShopConfigScreen.GUI_PROFILE.BUTTON_BUY)
-    self.presetsButton:setInputAction(InputAction.MENU_EXTRA_1)
+    self.presetsButton:setInputAction(InputAction.VEHICLE_PRESETS)
     self.presetsButton.onClickCallback = function()
       ShopConfigScreenExtension.onOpenPresetsDialog(self)
     end
@@ -215,6 +215,16 @@ end
 
 ---
 ShopConfigScreen.updateButtons = Utils.overwrittenFunction(ShopConfigScreen.updateButtons, updateButtons)
+
+---Register custom action in ShopConfigScreen input context
+local function registerInputActionsAppended(self)
+  g_inputBinding:registerActionEvent(InputAction.VEHICLE_PRESETS, self, function()
+    ShopConfigScreenExtension.onOpenPresetsDialog(self)
+  end, false, true, false, true)
+end
+
+---
+ShopConfigScreen.registerInputActions = Utils.appendedFunction(ShopConfigScreen.registerInputActions, registerInputActionsAppended)
 
 ---Save data when preview vehicles are deleted called from onClose
 local function deletePreviewVehiclesAppended(self)

--- a/scripts/extensions/ShopMenuExtension.lua
+++ b/scripts/extensions/ShopMenuExtension.lua
@@ -42,7 +42,7 @@ local function ensurePresetsButton(self)
   end
 
   self.vehiclePresetsButtonInfo = {
-    inputAction = InputAction.MENU_EXTRA_1,
+    inputAction = InputAction.VEHICLE_PRESETS,
     text = g_i18n:getText("vehiclePresets_presets"),
     callback = self:makeSelfCallback(ShopMenuExtension.onButtonVehiclePresets)
   }


### PR DESCRIPTION
Replaces hardcoded `MENU_EXTRA_1` with a custom `VEHICLE_PRESETS` action
registered in modDesc, allowing users to rebind the key in game settings.

- Default key: V
- Registers action in ShopConfigScreen input context
- Adds l10n translations for all 28 languages
- Bumps version to 1.0.1.0
- Bumps descVersion to 108
