### PR TITLE
feat: implement portable presets with relative storage paths

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
   <author>aaw3k</author>
-  <version>1.0.1.0</version>
+  <version>1.0.2.0</version>
 
   <title>
     <en>Vehicle Presets</en>
@@ -20,14 +20,15 @@ Features:
 - Supported configurations include base variants, multiple custom colors, and material changes.
 - Instantly apply, overwrite, or delete your saved configurations.
 - Browse all accumulated presets organized by vehicle in the global browser.
-- Automatically removes presets for uninstalled mod vehicles.
 
 Hotkeys:
 - Press 'V' to open the "All Presets" browser directly from the store pages.
 - Press 'V' to open the "Presets" dialog in the shop configuration screen.
 
-Changelog Version 1.0.1.0:
-- Added ability to change the keybind for opening preset dialogs.
+Changelog Version 1.0.2.0:
+- Added ability to change the keybind for opening preset dialogs (1.0.1.0).
+- Introduced relative save paths, ensuring presets are not deleted when changing the mod folder location.
+- Removed automatic deletion of presets for uninstalled mods due to the changes above.
 
 For more info, bug reports, or to contribute, check out GitHub (modnext/vehiclePresets).
 ]]></en>
@@ -39,14 +40,15 @@ Funktionen:
 - Unterstützte Konfigurationen sind Grundbausteine, jegliche Farbanpassungen und Materialänderungen.
 - Wende sofort deine gespeicherten Konfigurationen an, überschreibe oder lösche sie.
 - Durchschaut alle deine gesammelten Presets, sortiert nach Fahrzeugen, im globalen Browser.
-- Entfernt automatisch Presets für deinstallierte Mod-Fahrzeuge.
 
 Tastenkombinationen:
 - Drücke 'V', um den "Alle Presets"-Browser direkt aus dem Menü zu öffnen.
 - Drücke 'V', um den "Presets"-Dialog im Shop-Konfigurationsbildschirm zu öffnen.
 
-Changelog Version 1.0.1.0:
-- Möglichkeit hinzugefügt, die Tastenbelegung zum Öffnen der Preset-Dialoge zu ändern.
+Changelog Version 1.0.2.0:
+- Möglichkeit hinzugefügt, die Tastenbelegung zum Öffnen der Preset-Dialoge zu ändern (1.0.1.0).
+- Relative Speicherpfade eingeführt, wodurch Presets beim Ändern des Mod-Ordner-Speicherorts nicht mehr gelöscht werden.
+- Automatisches Löschen von Presets für deinstallierte Mods aufgrund der oben genannten Änderungen entfernt.
 
 Für mehr Infos, Fehlermeldungen oder kleine Beiträge schau einfach auf GitHub vorbei (modnext/vehiclePresets).
 ]]></de>
@@ -58,14 +60,15 @@ Fonctionnalités :
 - Les configurations prises en charge incluent les variantes de base, les couleurs personnalisées et les matériaux.
 - Appliquez, écrasez ou supprimez instantanément vos configurations.
 - Parcourez tous vos préréglages enregistrés, triés par véhicule, dans le navigateur global.
-- Supprime automatiquement les préréglages des véhicules de mods désinstallés.
 
 Raccourcis clavier :
 - Appuyez sur 'V' pour ouvrir le navigateur "Préréglages" directement depuis les pages de la boutique.
 - Appuyez sur 'V' pour ouvrir la boîte de dialogue "Préréglages" dans l'écran de configuration.
 
-Changelog Version 1.0.1.0 :
-- Ajout de la possibilité de modifier la touche pour ouvrir les dialogues de préréglages.
+Changelog Version 1.0.2.0 :
+- Ajout de la possibilité de modifier la touche pour ouvrir les dialogues de préréglages (1.0.1.0).
+- Introduction des chemins de sauvegarde relatifs, garantissant que les préréglages ne sont pas supprimés lors du changement d'emplacement du dossier de mods.
+- Suppression de l'effacement automatique des préréglages pour les mods désinstallés en raison des changements ci-dessus.
 
 Pour plus d'infos, signaler un bug ou apporter votre aide, rendez-vous sur GitHub (modnext/vehiclePresets).
 ]]></fr>
@@ -77,14 +80,15 @@ Funkcje:
 - Zapisywane konfiguracje obejmują warianty ogólne, wszystkie customowe kolory i zmiany materiałów.
 - Błyskawicznie wczytuj, nadpisuj oraz usuwaj swoje konfiguracje.
 - Przeglądaj utworzone presety rozdzielone na poszczególne pojazdy w globalnej liście.
-- Automatycznie usuwa presety dla pojazdów z odinstalowanych modów.
 
 Skróty klawiszowe:
 - Wciśnij 'V', aby otworzyć przeglądarkę "Wszystkich Presetów" prosto ze stron sklepu.
 - Wciśnij 'V', aby otworzyć okno presetów w ekranie konfiguracji pojazdu.
 
-Changelog Version 1.0.1.0:
-- Dodano możliwość zmiany klawisza do otwierania okien presetów.
+Changelog Version 1.0.2.0:
+- Dodano możliwość zmiany klawisza do otwierania okien presetów (1.0.1.0).
+- Wprowadzono względne ścieżki zapisu, dzięki czemu presety nie usuną się po zmianie lokalizacji folderu z modami.
+- Usunięto automatyczne usuwanie presetów dla odinstalowanych modów na skutek powyższych zmian.
 
 Więcej informacji, zgłaszanie błędów czy pomoc w rozwoju znajdziecie na moim GitHubie (modnext/vehiclePresets).
 ]]></pl>
@@ -95,14 +99,15 @@ Więcej informacji, zgłaszanie błędów czy pomoc w rozwoju znajdziecie na moi
 - Поддерживаемые настройки включают базовые конфигурации, пользовательские цвета и материалы.
 - Мгновенно применяйте, перезаписывайте или удаляйте сохраненные конфигурации.
 - Просматривайте все накопленные пресеты, отсортированные по транспортным средствам в глобальном браузере.
-- Автоматически удаляет пресеты для техники из удаленных модов.
 
 Горячие клавиши:
 - Нажмите «V», чтобы открыть браузер «Все пресеты» прямо со страниц магазина.
 - Нажмите «V», чтобы открыть диалоговое окно «Пресеты» на экране конфигурации.
 
-Changelog Version 1.0.1.0:
-- Добавлена возможность изменить клавишу для открытия диалогов пресетов.
+Changelog Version 1.0.2.0:
+- Добавлена возможность изменить клавишу для открытия диалогов пресетов (1.0.1.0).
+- Введены относительные пути сохранения, благодаря чему пресеты не удаляются при изменении расположения папки с модами.
+- Удалено автоматическое удаление пресетов для удаленных модов в связи с вышеуказанными изменениями.
 
 Для получения дополнительной информации, сообщений об ошибках или участия загляните на GitHub (modnext/vehiclePresets).
 ]]></ru>

--- a/scripts/VehiclePresetsSystem.lua
+++ b/scripts/VehiclePresetsSystem.lua
@@ -102,21 +102,8 @@ function VehiclePresetsSystem:resolveStorageKeys()
     end
 
     if runtimeKey ~= nil then
-      if resolvedVehicles[runtimeKey] == nil then
-        resolvedVehicles[runtimeKey] = presets
-        resolvedIds[runtimeKey] = self.vehicleIds[key]
-      else
-        for _, preset in ipairs(presets) do
-          if #resolvedVehicles[runtimeKey] < VehiclePresetsSystem.MAX_PRESETS_PER_VEHICLE then
-            table.insert(resolvedVehicles[runtimeKey], preset)
-          end
-        end
-
-        local existingId = resolvedIds[runtimeKey] or 0
-        local newId = self.vehicleIds[key] or 0
-        resolvedIds[runtimeKey] = math.max(existingId, newId)
-        self:markDirty()
-      end
+      resolvedVehicles[runtimeKey] = presets
+      resolvedIds[runtimeKey] = self.vehicleIds[key]
 
       local storeItem = g_storeManager:getItemByXMLFilename(runtimeKey)
 

--- a/scripts/VehiclePresetsSystem.lua
+++ b/scripts/VehiclePresetsSystem.lua
@@ -36,16 +36,26 @@ function VehiclePresetsSystem:markDirty()
   self.isDirty = true
 end
 
----Extract mod-relative storage key from an absolute xmlFilename
+---Extract relative storage key from an absolute xmlFilename
 -- @param string xmlFilename absolute or relative xml filename
--- @return string|nil storageKey mod-relative path preserving original case
+-- @return string|nil storageKey relative path preserving original case
 function VehiclePresetsSystem.toStorageKey(xmlFilename)
   if xmlFilename == nil then
     return nil
   end
 
   local normalized = xmlFilename:gsub("\\", "/")
-  local pos = string.lower(normalized):find("fs25_")
+  local lower = string.lower(normalized)
+
+  local pos = lower:find("fs25_")
+
+  if pos == nil then
+    pos = lower:find("pdlc/")
+  end
+
+  if pos == nil then
+    pos = lower:find("data/")
+  end
 
   if pos ~= nil then
     return normalized:sub(pos)

--- a/scripts/VehiclePresetsSystem.lua
+++ b/scripts/VehiclePresetsSystem.lua
@@ -77,7 +77,6 @@ end
 
 ---Resolve storage keys to current runtime absolute paths
 -- Migrates mod-relative and old absolute keys to current xmlFilenames
--- and merges duplicate entries that resolve to the same vehicle
 function VehiclePresetsSystem:resolveStorageKeys()
   local storageKeyToXml = {}
 
@@ -102,21 +101,8 @@ function VehiclePresetsSystem:resolveStorageKeys()
     end
 
     if runtimeKey ~= nil then
-      if resolvedVehicles[runtimeKey] == nil then
-        resolvedVehicles[runtimeKey] = presets
-        resolvedIds[runtimeKey] = self.vehicleIds[key]
-      else
-        for _, preset in ipairs(presets) do
-          if #resolvedVehicles[runtimeKey] < VehiclePresetsSystem.MAX_PRESETS_PER_VEHICLE then
-            table.insert(resolvedVehicles[runtimeKey], preset)
-          end
-        end
-
-        local existingId = resolvedIds[runtimeKey] or 0
-        local newId = self.vehicleIds[key] or 0
-        resolvedIds[runtimeKey] = math.max(existingId, newId)
-        self:markDirty()
-      end
+      resolvedVehicles[runtimeKey] = presets
+      resolvedIds[runtimeKey] = self.vehicleIds[key]
 
       local storeItem = g_storeManager:getItemByXMLFilename(runtimeKey)
 

--- a/scripts/VehiclePresetsSystem.lua
+++ b/scripts/VehiclePresetsSystem.lua
@@ -22,6 +22,7 @@ function VehiclePresetsSystem.new()
   self.nextVehicleId = 1
 
   self.isDirty = false
+  self.isResolved = false
   self.hasSyncedThisSession = false
 
   -- load data from xml file
@@ -35,10 +36,108 @@ function VehiclePresetsSystem:markDirty()
   self.isDirty = true
 end
 
+---Extract mod-relative storage key from an absolute xmlFilename
+-- @param string xmlFilename absolute or relative xml filename
+-- @return string|nil storageKey mod-relative path preserving original case
+function VehiclePresetsSystem.toStorageKey(xmlFilename)
+  if xmlFilename == nil then
+    return nil
+  end
+
+  local normalized = xmlFilename:gsub("\\", "/")
+  local pos = string.lower(normalized):find("fs25_")
+
+  if pos ~= nil then
+    return normalized:sub(pos)
+  end
+
+  return normalized
+end
+
+---Ensure storage keys are resolved to current runtime paths
+-- Runs resolution exactly once per session on first access
+function VehiclePresetsSystem:ensureResolved()
+  if self.isResolved then
+    return
+  end
+
+  self.isResolved = true
+  self:resolveStorageKeys()
+end
+
+---Resolve storage keys to current runtime absolute paths
+-- Migrates mod-relative and old absolute keys to current xmlFilenames
+-- and merges duplicate entries that resolve to the same vehicle
+function VehiclePresetsSystem:resolveStorageKeys()
+  local storageKeyToXml = {}
+
+  if g_storeManager.xmlFilenameToItem ~= nil then
+    for xmlFilename, _ in pairs(g_storeManager.xmlFilenameToItem) do
+      local storageKey = string.lower(VehiclePresetsSystem.toStorageKey(xmlFilename))
+      storageKeyToXml[storageKey] = xmlFilename
+    end
+  end
+
+  local resolvedVehicles = {}
+  local resolvedIds = {}
+
+  for key, presets in pairs(self.vehicles) do
+    local runtimeKey = nil
+    local storageKey = string.lower(VehiclePresetsSystem.toStorageKey(key))
+
+    if g_storeManager:getItemByXMLFilename(key) ~= nil then
+      runtimeKey = string.lower(key)
+    elseif storageKeyToXml[storageKey] ~= nil then
+      runtimeKey = string.lower(storageKeyToXml[storageKey])
+    end
+
+    if runtimeKey ~= nil then
+      if resolvedVehicles[runtimeKey] == nil then
+        resolvedVehicles[runtimeKey] = presets
+        resolvedIds[runtimeKey] = self.vehicleIds[key]
+      else
+        for _, preset in ipairs(presets) do
+          if #resolvedVehicles[runtimeKey] < VehiclePresetsSystem.MAX_PRESETS_PER_VEHICLE then
+            table.insert(resolvedVehicles[runtimeKey], preset)
+          end
+        end
+
+        local existingId = resolvedIds[runtimeKey] or 0
+        local newId = self.vehicleIds[key] or 0
+        resolvedIds[runtimeKey] = math.max(existingId, newId)
+        self:markDirty()
+      end
+
+      local storeItem = g_storeManager:getItemByXMLFilename(runtimeKey)
+
+      if storeItem ~= nil then
+        for _, preset in ipairs(resolvedVehicles[runtimeKey]) do
+          preset.xmlFilename = storeItem.xmlFilename
+        end
+      end
+    else
+      resolvedVehicles[key] = presets
+      resolvedIds[key] = self.vehicleIds[key]
+    end
+  end
+
+  for key, _ in pairs(self.vehicles) do
+    if resolvedVehicles[key] == nil then
+      self:markDirty()
+      break
+    end
+  end
+
+  self.vehicles = resolvedVehicles
+  self.vehicleIds = resolvedIds
+end
+
 ---Get all presets for a specific vehicle
 -- @param string xmlFilename vehicle xml filename identifier
 -- @return table presets list of preset entries
 function VehiclePresetsSystem:getPresetsForVehicle(xmlFilename)
+  self:ensureResolved()
+
   if xmlFilename == nil then
     return {}
   end
@@ -360,29 +459,14 @@ function VehiclePresetsSystem:renamePreset(xmlFilename, presetIndex, newName)
   self:markDirty()
 end
 
----Synchronize presets and remove vehicles belonging to uninstalled mods
+---Synchronize presets with currently loaded mods
 function VehiclePresetsSystem:sync()
   if self.hasSyncedThisSession then
     return
   end
 
   self.hasSyncedThisSession = true
-  local toRemove = {}
-
-  for xmlFilename, _ in pairs(self.vehicles) do
-    local storeItem = g_storeManager:getItemByXMLFilename(xmlFilename)
-
-    if storeItem == nil then
-      table.insert(toRemove, xmlFilename)
-    end
-  end
-
-  for _, xmlFilename in ipairs(toRemove) do
-    self.vehicles[xmlFilename] = nil
-    self.vehicleIds[xmlFilename] = nil
-    self:markDirty()
-  end
-
+  self:ensureResolved()
   self:saveIfDirty()
 end
 
@@ -392,6 +476,7 @@ function VehiclePresetsSystem:loadFromXMLFile()
   self.vehicleIds = {}
   self.nextVehicleId = 1
   self.isDirty = false
+  self.isResolved = false
 
   local xmlFile = XMLFile.loadIfExists("VehiclePresetsXML", modSettingsDirectory .. "presets.xml")
 
@@ -553,7 +638,7 @@ function VehiclePresetsSystem:saveToXMLFile()
         xmlFile:setInt(vehicleKey .. "#id", vehicleId)
       end
 
-      xmlFile:setString(vehicleKey .. "#xmlFilename", presets[1].xmlFilename)
+      xmlFile:setString(vehicleKey .. "#xmlFilename", VehiclePresetsSystem.toStorageKey(presets[1].xmlFilename))
 
       for presetIdx, preset in ipairs(presets) do
         local presetKey = string.format("%s.preset(%d)", vehicleKey, presetIdx - 1)


### PR DESCRIPTION
## Description
This Pull Request resolves #3 by migrating the preset saving mechanism to use relative paths instead of absolute system paths.

### Changes
* **Portable Presets:** Changed the `toStorageKey` system to generate relative paths for saved vehicles. This allows vehicle presets to properly survive `modsDirectoryOverride` changes and transferring saves across disks.
* **Code Simplification:** Dropped the legacy preset deduplication flow from `resolveStorageKeys` since it is no longer necessary under the new parsing rules.
* **Changelog:** Bumped the `modDesc.xml` version to 1.0.2.0 and added localized feature changes to reflect the new functionality.
