### PR TITLE
fix: prevent save error when applying preset by not wiping configurationData

### DIFF
--- a/scripts/extensions/ShopConfigScreenExtension.lua
+++ b/scripts/extensions/ShopConfigScreenExtension.lua
@@ -96,8 +96,6 @@ function ShopConfigScreenExtension.applyPreset(self, presetIndex)
   end
 
   -- restore configurationData for custom colors
-  self.configurationData = {}
-
   if preset.configurationData ~= nil then
     for configName, data in pairs(preset.configurationData) do
       if self.configurationData[configName] == nil then


### PR DESCRIPTION
Fixes #8

Applying a preset wiped `self.configurationData = {}` and only repopulated
entries from the preset. When the game saved bought configurations,
`ConfigurationUtil` found `configurationData[configName]` existed but
`data[configId]` was nil for configs not in the preset, passing nil to
`VehicleConfigurationItemColor:saveToXMLFile` which crashed on `nil.color`.

Fix: overlay preset entries on existing configurationData instead of wiping it.
